### PR TITLE
Add a manpage and prepare setaudit to be added to ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC?=	cc
 CFLAGS+=	-Wall
 TARGET=	setaudit
 OBJS=	setaudit.o
+PREFIX?=	/usr/local
 
 LIBS=	-lbsm
 
@@ -12,6 +13,10 @@ all:	$(TARGET)
 
 setaudit:	$(OBJS)
 		$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+
+install:	setaudit
+		mkdir -p $(PREFIX)/bin/
+		install -m 0555 setaudit $(PREFIX)/bin/setaudit
 
 clean:
 	rm -fr *.o setaudit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC?=	cc
-CFLAGS=	-Wall
+CFLAGS+=	-Wall
 TARGET=	setaudit
 OBJS=	setaudit.o
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Tool to specify audit configurations on a process
 ## Usage
 
 ```shell
-usage: ./setaudit [-a auid] [-m mask] [-s source] [-p port] comand ...
+usage: ./setaudit [-a auid] [-m mask] [-s source] [-p port] command ...
 ```
 ## Example
 
 Enable all exe related audit events performed by `command` and it's child processes
 
 ```shell
-sudo ./setaudit -m ex  command
+sudo ./setaudit -m ex command
 ```

--- a/setaudit.1
+++ b/setaudit.1
@@ -1,0 +1,73 @@
+.\" Copyright (c) 2018 Mateusz Piotrowski <0mp@FreeBSD.org>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.Dd March 14, 2018
+.Dt SETAUDIT 1
+.Os
+.Sh NAME
+.Nm setaudit
+.Nd "specify audit configurations on a process"
+.Sh SYNOPSIS
+.Nm
+.Op Fl a Ar auid
+.Op Fl m Ar mask
+.Op Fl s Ar source
+.Op Fl p Ar port
+.Ar command ...
+.Sh DESCRIPTION
+.Nm
+is a tool to specify audit configurations on a process.
+.Pp
+The following options are available:
+.Bl -tag -width ".Fl d Ar argument"
+.It Fl a
+Audit user ID.
+.It Fl m
+String representation of an audit mask.
+.It Fl s
+IPv4 or IPv6 address of a Terminal ID.
+.It Fl p
+Port of a Terminal ID.
+.Xr
+.El
+.Sh EXAMPLES
+Enable all exe related audit events performed by
+.Ar command
+and it's child processes:
+.Pp
+.Dl # setaudit -m ex command
+.Sh SEE ALSO
+.Xr getaudit 2 ,
+.Xr au_mask 3 ,
+.Xr libbsm 3 ,
+.Xr audit_user 5 ,
+.Xr audit 8
+.Sh HISTORY
+The
+.Nm
+utility was written by
+.An Christian S.J. Peron Aq Mt csjp@FreeBSD.org .
+.Sh AUTHORS
+This
+manual page was written by
+.An Mateusz Piotrowski Aq Mt 0mp@FreeBSD.org .

--- a/setaudit.c
+++ b/setaudit.c
@@ -48,7 +48,7 @@ usage(char *prog)
 {
 
 	(void) fprintf(stderr,
-	    "usage: %s [-a auid] [-m mask] [-s source] [-p port] comand ...\n",
+	    "usage: %s [-a auid] [-m mask] [-s source] [-p port] command ...\n",
 	    prog);
 	exit(1);
 }


### PR DESCRIPTION
Hi,

I 've written a simple manpage and improved the Makefile a little bit so that it is easier to add setaudit to the FreeBSD ports.

I'll submit a new port to Bugzilla if you decide to merge these changes :)

Have a great day!